### PR TITLE
Reverse loop over messages to find quoted message. Improves performance as quoted messages will be near the current message (end of the messages iterator).

### DIFF
--- a/source/WhatsApp/QueryMessagesThread.cpp
+++ b/source/WhatsApp/QueryMessagesThread.cpp
@@ -22,11 +22,11 @@ void QueryMessagesThread::interrupt()
 	sqlite3_interrupt(sqLiteDatabase.getHandle());
 }
 
-WhatsappMessage *QueryMessagesThread::findByMessageId(const std::string &messageId)
+WhatsappMessage *QueryMessagesThread::findByMessageIdReverse(const std::string &messageId)
 {
-	for(std::vector<WhatsappMessage *>::iterator it = messages.begin(); it != messages.end(); ++it)
+	for (std::vector<WhatsappMessage *>::reverse_iterator it = messages.rbegin(); it != messages.rend(); ++it)
 	{
-		WhatsappMessage *message = *it;
+		WhatsappMessage  *message = *it;
 		if (message->getMessageId() == messageId)
 		{
 			return message;
@@ -92,7 +92,7 @@ void QueryMessagesThread::run()
 		WhatsappMessage *quotedMessage = NULL;
 		if (quotedMessageId.length() > 0)
 		{
-			quotedMessage = findByMessageId(quotedMessageId);
+			quotedMessage = findByMessageIdReverse(quotedMessageId);
 		}
 		WhatsappMessage *message = new WhatsappMessage(messageId, chatId, fromMe == 1, status, data, timestamp, 0, 0, mediaUrl, mediaMimeType, mediaWhatsappType, mediaSize, mediaName, mediaCaption, mediaDuration, latitude, longitude, thumbImage, thumbImageSize, remoteResource, rawData, rawDataSize, thumbnailData, thumbnailDataSize, quotedMessage, linkId > 0);
 		messages.push_back(message);

--- a/source/WhatsApp/QueryMessagesThread.h
+++ b/source/WhatsApp/QueryMessagesThread.h
@@ -15,8 +15,8 @@ private:
 	SQLiteDatabase &sqLiteDatabase;
 	const std::string &chatId;
 	std::vector<WhatsappMessage *> &messages;
-
-	WhatsappMessage *findByMessageId(const std::string &messageId);
+	
+	WhatsappMessage *findByMessageIdReverse(const std::string &messageId);
 
 public:
 	QueryMessagesThread(WhatsappDatabase &database, SQLiteDatabase &sqLiteDatabase, const std::string &chatId, std::vector<WhatsappMessage *> &messages);


### PR DESCRIPTION
Opening a large chat (250k+ messages) takes a long time. One of reasons for this is the loop which tries to find a quoted message. This loop starts from the beginning of the messages and loops to the end. Almost always one will quote a recent message (near the end of the messages vector). I changed findMessageById method to findMessageByIdReverse so it runs from the end of the vector to the front. This greatly improves performance as the quoted messages is often found in a couple of iterations. 